### PR TITLE
Bump GitBucket to 3.12.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,10 @@ scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8", "-featur
 
 resolvers += Resolver.jcenterRepo
 
-// resolvers += "amateras-repo" at "http://amateras.sourceforge.jp/mvn/"
-resolvers += "gitbucket-mirror" at "https://dl.bintray.com/yaroot/mirror-gitbucket/"
+resolvers += "amateras-repo" at "http://amateras.sourceforge.jp/mvn/"
+// resolvers += "gitbucket-mirror" at "https://dl.bintray.com/yaroot/mirror-gitbucket/"
 
 libraryDependencies ++= Seq(
-  "gitbucket"          % "gitbucket-assembly" % "3.11.0"  % "provided",
+  "gitbucket"          % "gitbucket-assembly" % "3.12.0"  % "provided",
   "javax.servlet"      % "javax.servlet-api"  % "3.1.0"   % "provided"
 )


### PR DESCRIPTION
GItBucket v3.12.0 has been released.

https://github.com/gitbucket/gitbucket/releases/tag/3.12

Since gitbucket-assembly has been released 3.12.0, I changed libraryDependencies.